### PR TITLE
release/v2.1.0-rc.1

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET
 
 on:
   push:
-    branches: [ main, dev, dev/*, feature/*, fix/*, release/* ]
+    branches: [ main, dev, feature/*, fix/*, release/* ]
 
   pull_request:
     branches: [ main ]
@@ -17,18 +17,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
-        include-prerelease: false
+        dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
+
+    # Create Local NuGet Source
 
     - name: Create Local NuGet Directory
       run: mkdir ~/nuget
 
     - name: Add Local Nuget Source
       run: dotnet nuget add source ~/nuget
+
+     # ServiceProviderExtensions
 
     - name: Restore Dependency.ServiceProviderExtensions
       run: dotnet restore ./src/*/*/ServiceProviderExtensions.csproj
@@ -45,6 +51,8 @@ jobs:
     - name: Test Dependency.ServiceProviderExtensions.Tests
       run: dotnet test ./src/*/*/ServiceProviderExtensions.Tests.csproj --no-restore  -c Release
 
+    # Dependency.Core
+
     - name: Restore Dependency.Core
       run: dotnet restore ./src/*/*/Dependency.Core.csproj
 
@@ -60,6 +68,8 @@ jobs:
     - name: Test Dependency.Core.Tests
       run: dotnet test ./src/*/*/Dependency.Core.Tests.csproj --no-restore  -c Release
 
+    # Dependency
+
     - name: Restore Dependency
       run: dotnet restore ./src/*/*/Dependency.csproj
 
@@ -69,6 +79,12 @@ jobs:
     - name: Pack Dependency
       run: dotnet pack ./src/*/*/Dependency.csproj --no-restore -o ~/nuget  -c Release
 
+      # Push
+
     - name: Push Packages
       if: ${{ github.event_name == 'release' }}
-      run: dotnet nuget push "../../../nuget/*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.NuGetSourcePassword }} --skip-duplicate
+      run: >
+        dotnet nuget push "../../../nuget/*.nupkg"
+        -s https://api.nuget.org/v3/index.json
+        -k ${{ secrets.NuGetSourcePassword }}
+        --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -301,7 +301,7 @@ node_modules/
 *.dsw
 *.dsp
 
-# Visual Studio 6 technical files 
+# Visual Studio 6 technical files
 *.ncb
 *.aps
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 Andrei Sergeev, Pavel Moskovoy
+Copyright (c) 2020-2023 Andrei Sergeev, Pavel Moskovoy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/dependency-core/Core.Tests/Dependency.Core.Tests.csproj
+++ b/src/dependency-core/Core.Tests/Dependency.Core.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2020-2022 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <Copyright>Copyright © 2020-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
     <RootNamespace>PrimeFuncPack.Tests</RootNamespace>
     <AssemblyName>PrimeFuncPack.Dependency.Core.Tests</AssemblyName>
   </PropertyGroup>
@@ -18,15 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="PrimeFuncPack.UnitTest.Data" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/dependency-core/Core.Tests/Tests.Dependency.01/With.02/With.02.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.01/With.02/With.02.cs
@@ -10,7 +10,7 @@ partial class OneDependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void WithOne_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string secondValue)
+        string? secondValue)
     {
         var sourceValue = PlusFifteenIdRefType;
         var source = Dependency.From(_ => sourceValue);

--- a/src/dependency-core/Core.Tests/Tests.Dependency.01/With.06/With.06.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.01/With.06/With.06.cs
@@ -10,7 +10,7 @@ partial class OneDependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void WithFive_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string lastValue)
+        string? lastValue)
     {
         var sourceValue = new { Value = decimal.MaxValue };
         var source = Dependency.From(_ => sourceValue);

--- a/src/dependency-core/Core.Tests/Tests.Dependency.02/With.03/With.03.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.02/With.03/With.03.cs
@@ -10,7 +10,7 @@ partial class TwoDependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void WithOne_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string thirdValue)
+        string? thirdValue)
     {
         var firstSource = SomeTextStructType;
         var secondSource = PlusFifteenIdSomeStringNameRecord;

--- a/src/dependency-core/Core.Tests/Tests.Dependency.02/With.05/With.05.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.02/With.05/With.05.cs
@@ -10,7 +10,7 @@ partial class TwoDependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void WithThree_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string lastValue)
+        string? lastValue)
     {
         var firstSource = PlusFifteenIdRefType;
         var secondSource = decimal.MinusOne;

--- a/src/dependency-core/Core.Tests/Tests.Dependency.02/With.06/With.06.Resolver.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.02/With.06/With.06.Resolver.cs
@@ -92,7 +92,7 @@ partial class TwoDependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void WithFourResolvers_OthersAreNotNull_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string lastValue)
+        string? lastValue)
     {
         var firstSource = PlusFifteenIdLowerSomeStringNameRecord;
         var secondSource = MinusFifteenIdRefType;

--- a/src/dependency-core/Core.Tests/Tests.Dependency.03/With.04/With.04.Factory.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.03/With.04/With.04.Factory.cs
@@ -24,7 +24,7 @@ partial class ThreeDependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void WithOneFactory_FourthIsNotNull_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string fourthValue)
+        string? fourthValue)
     {
         var firstSource = LowerSomeTextStructType;
         var secondSource = MinusFifteenIdRefType;

--- a/src/dependency-core/Core.Tests/Tests.Dependency.03/With.05/With.05.Resolver.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.03/With.05/With.05.Resolver.cs
@@ -43,7 +43,7 @@ partial class ThreeDependencyTest
     [InlineData(WhiteSpaceString)]
     [InlineData(UpperSomeString)]
     public void WithTwoResolvers_OthersAreNotNull_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string lastValue)
+        string? lastValue)
     {
         var firstSource = PlusFifteenIdLowerSomeStringNameRecord;
         var secondSource = byte.MaxValue;

--- a/src/dependency-core/Core.Tests/Tests.Dependency.04/With.07/With.07.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency.04/With.07/With.07.cs
@@ -10,7 +10,7 @@ partial class FourDependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void WithThree_ExpectResolvedValuesAreEqualToSourceAndOther(
-        string lastValue)
+        string? lastValue)
     {
         var firstSource = TabString;
         var secondSource = MinusFifteenIdNullNameRecord;

--- a/src/dependency-core/Core.Tests/Tests.Dependency/07.Factory/07.From.Factory.cs
+++ b/src/dependency-core/Core.Tests/Tests.Dependency/07.Factory/07.From.Factory.cs
@@ -172,7 +172,7 @@ partial class DependencyTest
     [InlineData(EmptyString)]
     [InlineData(SomeString)]
     public void From_Factory_07_FactoriesAreNotNull_ExpectResolvedValuesAreEqualToSource(
-        string sourceSeventh)
+        string? sourceSeventh)
     {
         var sourceFirst = PlusFifteenIdRefType;
         var sourceSecond = long.MaxValue;

--- a/src/dependency-core/Core/Dependency.Core.csproj
+++ b/src/dependency-core/Core/Dependency.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
@@ -13,11 +13,11 @@
     <RepositoryUrl>https://github.com/pfpack/pfpack-dependency</RepositoryUrl>
     <Company>pfpack</Company>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2020-2022 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <Copyright>Copyright © 2020-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
     <Description>PrimeFuncPack Dependency.Core is a core library for .NET providing a functional programming based technology to build consistent dependency trees validated in the compile time.</Description>
     <RootNamespace>PrimeFuncPack</RootNamespace>
     <AssemblyName>PrimeFuncPack.Dependency.Core</AssemblyName>
-    <Version>2.0.2</Version>
+    <Version>2.1.0-rc.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrimeFuncPack.Core.Unit" Version="2.1.3" />
+    <PackageReference Include="PrimeFuncPack.Core.Unit" Version="2.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/dependency-service-provider-extensions/ServiceProviderExtensions.Tests/ServiceProviderExtensions.Tests.csproj
+++ b/src/dependency-service-provider-extensions/ServiceProviderExtensions.Tests/ServiceProviderExtensions.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsPackable>false</IsPackable>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2020-2021 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <Copyright>Copyright © 2020-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
     <RootNamespace>PrimeFuncPack.Tests</RootNamespace>
     <AssemblyName>PrimeFuncPack.Dependency.ServiceProviderExtensions.Tests</AssemblyName>
   </PropertyGroup>
@@ -18,15 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="PrimeFuncPack.UnitTest.Data" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/dependency-service-provider-extensions/ServiceProviderExtensions/Extensions.GetOrAbsent.cs
+++ b/src/dependency-service-provider-extensions/ServiceProviderExtensions/Extensions.GetOrAbsent.cs
@@ -12,11 +12,8 @@ partial class ServiceProviderExtensions
 
     private static Optional<T> InnerGetServiceOrAbsent<T>(IServiceProvider serviceProvider)
         where T : notnull
-    {
-        var service = serviceProvider.GetService(typeof(T));
-
-        return service is not null
-            ? new((T)service)
-            : default;
-    }
+        =>
+        serviceProvider.GetService(typeof(T)) is object service
+        ? new((T)service)
+        : default;
 }

--- a/src/dependency-service-provider-extensions/ServiceProviderExtensions/Extensions.GetOrThrow.cs
+++ b/src/dependency-service-provider-extensions/ServiceProviderExtensions/Extensions.GetOrThrow.cs
@@ -12,11 +12,8 @@ partial class ServiceProviderExtensions
 
     private static T InnerGetServiceOrThrow<T>(IServiceProvider serviceProvider)
         where T : notnull
-    {
-        var service = serviceProvider.GetService(typeof(T));
-
-        return service is not null
-            ? (T)service
-            : throw new InvalidOperationException($"A service of type {typeof(T)} cannot be resolved by the service provider.");
-    }
+        =>
+        serviceProvider.GetService(typeof(T)) is object service
+        ? (T)service
+        : throw new InvalidOperationException($"A service of type {typeof(T)} cannot be resolved by the service provider.");
 }

--- a/src/dependency-service-provider-extensions/ServiceProviderExtensions/ServiceProviderExtensions.csproj
+++ b/src/dependency-service-provider-extensions/ServiceProviderExtensions/ServiceProviderExtensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
@@ -13,11 +13,11 @@
     <RepositoryUrl>https://github.com/pfpack/pfpack-dependency</RepositoryUrl>
     <Company>pfpack</Company>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2020-2022 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <Copyright>Copyright © 2020-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
     <Description>PrimeFuncPack Dependency.ServiceProviderExtensions is a library for .NET providing useful extensions for the service provider.</Description>
     <RootNamespace>PrimeFuncPack</RootNamespace>
     <AssemblyName>PrimeFuncPack.Dependency.ServiceProviderExtensions</AssemblyName>
-    <Version>2.0.2</Version>
+    <Version>2.1.0-rc.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrimeFuncPack.Core.Optional" Version="2.0.1" />
+    <PackageReference Include="PrimeFuncPack.Core.Optional" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/dependency/Dependency/Dependency.csproj
+++ b/src/dependency/Dependency/Dependency.csproj
@@ -13,11 +13,11 @@
     <RepositoryUrl>https://github.com/pfpack/pfpack-dependency</RepositoryUrl>
     <Company>pfpack</Company>
     <Authors>Andrei Sergeev, Pavel Moskovoy</Authors>
-    <Copyright>Copyright © 2020-2022 Andrei Sergeev, Pavel Moskovoy</Copyright>
+    <Copyright>Copyright © 2020-2023 Andrei Sergeev, Pavel Moskovoy</Copyright>
     <Description>PrimeFuncPack Dependency is a framework for .NET providing a functional programming based technology to build consistent dependency trees validated in the compile time.</Description>
     <RootNamespace>PrimeFuncPack</RootNamespace>
     <AssemblyName>PrimeFuncPack.Dependency</AssemblyName>
-    <Version>2.0.2</Version>
+    <Version>2.1.0-rc.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PrimeFuncPack.Dependency.Core" Version="2.0.2" />
-    <PackageReference Include="PrimeFuncPack.Dependency.ServiceProviderExtensions" Version="2.0.2" />
+    <PackageReference Include="PrimeFuncPack.Dependency.Core" Version="2.1.0-rc.1" />
+    <PackageReference Include="PrimeFuncPack.Dependency.ServiceProviderExtensions" Version="2.1.0-rc.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
PrimeFuncPack Dependency:
- Add `.net6.0;.net7.0.net8.0` multi-target
- Update `Unit` dependency from `v2.1.3` to `v2.2.1`
- Update `Optional` dependency from `v2.0.1` to `v2.1.0`
- Update the test dependencies; Fix tests for the new `xUnit`
- Minor refactor (`Extensions.GetOrThrow` / `Extensions.GetOrAbsent`)
- `v2.1.0-rc.1`